### PR TITLE
[cloudian] Allow storage class to define IAM policy document.

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -70,11 +70,12 @@ provisioner: aws-s3.io/bucket
 parameters:
   region: <region e.g. reg-1>
   secretName: s3-bucket-owner
-  bucketName: <existing bucket name, e.g. photos, or delete>
   secretNamespace: s3-provisioner
+  bucketName: <existing bucket name, e.g. photos, or delete> - brownfield only
   s3Endpoint: <API server URL, e.g. http://s3-reg-1.landemo1.cloudian.eu>
   iamEndpoint: <IAM API server URL, e.g. http://iam.landemo1.cloudian.eu:16080>
-  storagePolicyId: <Storage Policy ID - or omit line to use default storage policy> 
+  storagePolicyId: <Storage Policy ID - or omit line to use default storage policy> - greenfield only
+  iamPolicy: <IAM policy document (JSON string) for users of this bucket - omit to use default IAM policy (read+write bucket)>
 reclaimPolicy: Delete
 ```
 
@@ -84,6 +85,18 @@ This file needs some customisation, depending on your setup.
 1. Change region, s3Endpoint and iamEndpoint to match your HyperStore setup
 1. For greenfield: delete bucketName and optionally set the storage policy to use for new buckets. Omit the storagePolicyId line to use the default policy. To find the policy ID, navigate to the Cluster->Storage Policies page on the CMC, select View/Edit for the policy, and copy the ID field (above the Policy Name field)
 1. For brownfield: specify an already created bucket name and delete reclaimPolicy and storagePolicyId
+1. Optionally specify an iam policy document to override default read+write access to the bucket. You do not need to specify `Resource` fields - they will be set to only allow access to the claimed bucket. For example, to grant read-only access to the bucket:
+```yaml
+  iamPolicy: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [{
+              "Sid": "AllowAll",
+              "Effect": "Allow",
+              "Action": ["s3:HeadObject", "s3:ListBucket", "s3:GetObject"]
+      }]
+    }
+```
 
 Apply this with:
 ```bash

--- a/cmd/aws-s3-provisioner.go
+++ b/cmd/aws-s3-provisioner.go
@@ -314,7 +314,7 @@ func (p *awsS3Provisioner) initializeCreateOrGrant(options *apibkt.BucketOptions
 // initializeUserAndPolicy sets commonly used provisioner
 // receiver fields, generates a unique username and calls
 // handleUserandPolicy.
-func (p *awsS3Provisioner) initializeUserAndPolicy() error {
+func (p *awsS3Provisioner) initializeUserAndPolicy(options *apibkt.BucketOptions) error {
 
 	//Create IAM service (maybe this should be added into our default or obc session
 	//or create all services type of function?
@@ -330,7 +330,7 @@ func (p *awsS3Provisioner) initializeUserAndPolicy() error {
 		p.bktUserName = p.createUserName(p.bucketName)
 
 		// handle all iam and policy operations
-		uAccess, uKey, err := p.handleUserAndPolicy(p.bucketName)
+		uAccess, uKey, err := p.handleUserAndPolicy(p.bucketName, options)
 		if err != nil || uAccess == "" || uKey == "" {
 			//what to do - something failed along the way
 			//do we fall back and create our connection with
@@ -404,7 +404,7 @@ func (p awsS3Provisioner) Provision(options *apibkt.BucketOptions) (*v1alpha1.Ob
 	// Bucket does exist, attach new user and policy wrapper
 	// calling initializeCreateOrGrant
 	// TODO: we currently are catching an error that is always nil
-	_ = p.initializeUserAndPolicy()
+	_ = p.initializeUserAndPolicy(options)
 
 	// returned ob with connection info
 	return p.rtnObjectBkt(p.bucketName), nil
@@ -429,7 +429,7 @@ func (p awsS3Provisioner) Grant(options *apibkt.BucketOptions) (*v1alpha1.Object
 	// Bucket does exist, attach new user and policy wrapper
 	// calling initializeUserAndPolicy
 	// TODO: we currently are catching an error that is always nil
-	_ = p.initializeUserAndPolicy()
+	_ = p.initializeUserAndPolicy(options)
 
 	// returned ob with connection info
 	// TODO: assuming this is the same Green vs Brown?

--- a/examples/brownfield/storageclass.yaml
+++ b/examples/brownfield/storageclass.yaml
@@ -14,3 +14,17 @@ parameters:
   s3Endpoint: http://s3-reg-1.landemo1.cloudian.eu
   iamEndpoint: http://iam.landemo1.cloudian.eu:16080
   bucketName: photos # the existing bucket claims will attach to
+
+  # Provide an IAM policy document to override the default IAM policy
+  # of read+write access to the bucket.
+  # Omit the "Resource" field - it will be set to only allow access to the claimed bucket
+  # For example to set a bucket read-only, uncomment the following:
+  #iamPolicy: |
+  #  {
+  #    "Version": "2012-10-17",
+  #    "Statement": [{
+  #            "Sid": "AllowAll",
+  #            "Effect": "Allow",
+  #            "Action": ["s3:HeadObject", "s3:ListBucket", "s3:GetObject"]
+  #    }]
+  #  }

--- a/examples/greenfield/storageclass.yaml
+++ b/examples/greenfield/storageclass.yaml
@@ -12,23 +12,8 @@ parameters:
   secretNamespace: s3-provisioner
   s3Endpoint: http://s3-reg-1.landemo1.cloudian.eu
   iamEndpoint: http://iam.landemo1.cloudian.eu:16080
-
   # Set storagePolicyId to create buckets with specified policy
   #storagePolicyId: <policy id>
-
-  # Provide an IAM policy document to override the default IAM policy
-  # of read+write access to the bucket.
-  # Omit the "Resource" field - it will be set to only allow access to the claimed bucket
-  # For example to set a bucket read-only, uncomment the following:
-  #iamPolicy: |
-  #  {
-  #    "Version": "2012-10-17",
-  #    "Statement": [{
-  #            "Sid": "AllowAll",
-  #            "Effect": "Allow",
-  #            "Action": ["s3:HeadObject", "s3:ListBucket", "s3:GetObject"]
-  #    }]
-  #  }
 
 # Delete bucket when object bucket claim is deleted
 reclaimPolicy: Delete

--- a/examples/greenfield/storageclass.yaml
+++ b/examples/greenfield/storageclass.yaml
@@ -12,7 +12,23 @@ parameters:
   secretNamespace: s3-provisioner
   s3Endpoint: http://s3-reg-1.landemo1.cloudian.eu
   iamEndpoint: http://iam.landemo1.cloudian.eu:16080
+
   # Set storagePolicyId to create buckets with specified policy
   #storagePolicyId: <policy id>
+
+  # Provide an IAM policy document to override the default IAM policy
+  # of read+write access to the bucket.
+  # Omit the "Resource" field - it will be set to only allow access to the claimed bucket
+  # For example to set a bucket read-only, uncomment the following:
+  #iamPolicy: |
+  #  {
+  #    "Version": "2012-10-17",
+  #    "Statement": [{
+  #            "Sid": "AllowAll",
+  #            "Effect": "Allow",
+  #            "Action": ["s3:HeadObject", "s3:ListBucket", "s3:GetObject"]
+  #    }]
+  #  }
+
 # Delete bucket when object bucket claim is deleted
 reclaimPolicy: Delete


### PR DESCRIPTION

1) If stroage class has policy document, use that instead of the default read+write policy
2) Pretty print stored policy document to make it easier to review from CMC
3) Update DEPLOY documentation and storageclass.yaml examples.