### PR TITLE
[common] KUB-1: Make IAM user creation optional.

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -76,6 +76,10 @@ parameters:
   iamEndpoint: <IAM API server URL, e.g. http://iam.landemo1.cloudian.eu:16080>
   storagePolicyId: <Storage Policy ID - or omit line to use default storage policy> - greenfield only
   iamPolicy: <IAM policy document (JSON string) for users of this bucket - omit to use default IAM policy (read+write bucket)>
+  createBucketUser: <optional - "yes" or "no", default is "yes">
+  bucketClaimUserSecretName: <A separate secret holding credentials object bucket claim>
+  bucketClaimUserSecretNamespace: <optional if createBucketUser is "yes". A separate secret holding credentials object bucket claim>
+
 reclaimPolicy: Delete
 ```
 
@@ -85,7 +89,8 @@ This file needs some customisation, depending on your setup.
 1. Change region, s3Endpoint and iamEndpoint to match your HyperStore setup
 1. For greenfield: delete bucketName and optionally set the storage policy to use for new buckets. Omit the storagePolicyId line to use the default policy. To find the policy ID, navigate to the Cluster->Storage Policies page on the CMC, select View/Edit for the policy, and copy the ID field (above the Policy Name field)
 1. For brownfield: specify an already created bucket name and delete reclaimPolicy and storagePolicyId
-1. Optionally specify an iam policy document to override default read+write access to the bucket. You do not need to specify `Resource` fields - they will be set to only allow access to the claimed bucket. For example, to grant read-only access to the bucket:
+1. Optionally disable IAM user creation for bucket access by setting `createBucketUser` to `"no"`. A separate secret can be used to hold a shared credentials granted to all object bucket claims for this storage class by setting `bucketClaimUserSecretName` and `bucketClaimUserSecretNamespace`. If this secret is unset, the credentials from the `secretNamespace/secretName` are provided to object bucket claims. 
+1. Optionally specify an IAM policy document to override default read+write access to the bucket. You do not need to specify `Resource` fields - they will be set to only allow access to the claimed bucket. For example, to grant read-only access to the bucket:
 ```yaml
   iamPolicy: |
     {
@@ -98,7 +103,7 @@ This file needs some customisation, depending on your setup.
     }
 ```
 
-Apply this with:
+Apply this with:                                                                                                    
 ```bash
 kubectl apply -f storage-class.yaml
 ```

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -75,10 +75,10 @@ parameters:
   s3Endpoint: <API server URL, e.g. http://s3-reg-1.landemo1.cloudian.eu>
   iamEndpoint: <IAM API server URL, e.g. http://iam.landemo1.cloudian.eu:16080>
   storagePolicyId: <Storage Policy ID - or omit line to use default storage policy> - greenfield only
-  iamPolicy: <IAM policy document (JSON string) for users of this bucket - omit to use default IAM policy (read+write bucket)>
-  createBucketUser: <optional - "yes" or "no", default is "yes">
-  bucketClaimUserSecretName: <A separate secret holding credentials object bucket claim>
-  bucketClaimUserSecretNamespace: <optional if createBucketUser is "yes". A separate secret holding credentials object bucket claim>
+  createBucketUser: <optional - control whether the provisioner creates IAM users. Either "yes" or "no", default is "yes">
+  bucketClaimUserSecretName: <optional - a separate secret holding credentials to provide to object bucket claim if user creation is disabled>
+  bucketClaimUserSecretNamespace: <namespace for bucketClaimUserSecretName, required if bucketClaimUserSecretName is set>
+  iamPolicy: <IAM policy document (JSON string) for users of this bucket - omit to use default IAM policy (read+write bucket). Only applies if IAM user creation enabled>
 
 reclaimPolicy: Delete
 ```
@@ -90,7 +90,7 @@ This file needs some customisation, depending on your setup.
 1. For greenfield: delete bucketName and optionally set the storage policy to use for new buckets. Omit the storagePolicyId line to use the default policy. To find the policy ID, navigate to the Cluster->Storage Policies page on the CMC, select View/Edit for the policy, and copy the ID field (above the Policy Name field)
 1. For brownfield: specify an already created bucket name and delete reclaimPolicy and storagePolicyId
 1. Optionally disable IAM user creation for bucket access by setting `createBucketUser` to `"no"`. A separate secret can be used to hold a shared credentials granted to all object bucket claims for this storage class by setting `bucketClaimUserSecretName` and `bucketClaimUserSecretNamespace`. If this secret is unset, the credentials from the `secretNamespace/secretName` are provided to object bucket claims. 
-1. Optionally specify an IAM policy document to override default read+write access to the bucket. You do not need to specify `Resource` fields - they will be set to only allow access to the claimed bucket. For example, to grant read-only access to the bucket:
+1. Optionally specify an IAM policy document to override default read+write access to the bucket. You do not need to specify `Resource` fields - they will be set to only allow access to the provisioned bucket. Only applicable if IAM user creation is enabled. For example, to grant read-only access to the bucket:
 ```yaml
   iamPolicy: |
     {
@@ -103,7 +103,7 @@ This file needs some customisation, depending on your setup.
     }
 ```
 
-Apply this with:                                                                                                    
+Apply this with:
 ```bash
 kubectl apply -f storage-class.yaml
 ```

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -91,6 +91,10 @@ func (p *awsS3Provisioner) handleUserAndPolicy(bktName string, options *apibkt.B
 
 func (p *awsS3Provisioner) handleUserAndPolicyDeletion(bktName string) error {
 
+	if p.bktCreateUser != "yes" {
+		return nil
+	}
+
 	glog.V(2).Infof("deleting user and policy for bucket %q", bktName)
 
 	uname := p.bktUserName
@@ -223,7 +227,7 @@ func (p *awsS3Provisioner) createBucketPolicyDocument(bktName string, options *a
 			return "", err
 		}
 		// Ensure each policy is tied to just this bucket
-		for idx, _ := range policy.Statement {
+		for idx := range policy.Statement {
 			policy.Statement[idx].Resource = []string{arn + "/*", arn}
 		}
 	} else {

--- a/cmd/iam.go
+++ b/cmd/iam.go
@@ -25,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/arn"
 	awsuser "github.com/aws/aws-sdk-go/service/iam"
 	"github.com/golang/glog"
-	"github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1"
 	apibkt "github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api"
 	storageV1 "k8s.io/api/storage/v1"
 )
@@ -386,9 +385,9 @@ func (p *awsS3Provisioner) createIAMUser(user string) (string, string, error) {
 	return p.bktUserAccessId, p.bktUserSecretKey, nil
 }
 
-// Get StorageClass from OBC and check params for createBucketUser and set
+// check storage class params for createBucketUser and set
 // provisioner receiver field.
-func (p *awsS3Provisioner) setCreateBucketUserOptions(obc *v1alpha1.ObjectBucketClaim, sc *storageV1.StorageClass) {
+func (p *awsS3Provisioner) setCreateBucketUserOptions(sc *storageV1.StorageClass) {
 
 	const scBucketUser = "createBucketUser"
 

--- a/examples/brownfield/storageclass.yaml
+++ b/examples/brownfield/storageclass.yaml
@@ -1,6 +1,6 @@
-# An object bucket provider that binds bucket claims to an 
+# An object bucket provider that binds bucket claims to an
 # existing (brownfield) bucket called "photos"
-# for every object bucket claim, and deletes the bucket 
+# for every object bucket claim, and deletes the bucket
 # when the object bucket claim is deleted
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
@@ -15,6 +15,12 @@ parameters:
   iamEndpoint: http://iam.landemo1.cloudian.eu:16080
   bucketName: photos # the existing bucket claims will attach to
 
+  # Specify a fixed set of credentials to use for all bucket claims
+  # instead of creating an IAM user per claim
+  #createBucketUser: "no"
+  #bucketClaimUserSecretName: s3-bucket-claim-user
+  #bucketClaimUserSecretNamespace: s3-provisioner
+  #
   # Provide an IAM policy document to override the default IAM policy
   # of read+write access to the bucket.
   # Omit the "Resource" field - it will be set to only allow access to the claimed bucket


### PR DESCRIPTION

If IAM user creation is disabled,
allow a separate secret to store credentials
provided to object bucket claim.

If no separate credential are specified, the bucket owner
credentials are used.